### PR TITLE
update build config and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: mfusg compiler checks
+name: mfusg checks
 on:
   # run at 6 AM UTC every day
   schedule:
@@ -26,10 +26,10 @@ jobs:
           # test latest gcc
           - {os: ubuntu-latest, compiler: gcc, version: 13, shell: bash, release: no}
           - {os: macos-14, compiler: gcc, version: 13, shell: bash, release: yes}
+          - {os: macos-15-intel, compiler: gcc, version: 13, shell: bash, release: yes}
           - {os: windows-latest, compiler: gcc, version: 13, shell: pwsh, release: no}
           # test intel-classic
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.7, shell: bash, release: no}
-          - {os: macos-15-intel, compiler: intel-classic, version: 2021.6, shell: bash, release: yes}
           # test previous gcc
           - {os: ubuntu-latest, compiler: gcc, version: 12, shell: bash, release: no}
           - {os: ubuntu-latest, compiler: gcc, version: 11, shell: bash, release: no}
@@ -64,6 +64,26 @@ jobs:
         run: |
           echo "ostag=$(pixi run get-ostag)" >> $GITHUB_ENV
 
+      # static link gfortran libs
+      - name: Hide dylibs (macOS)
+        if: runner.os == 'macOS'
+        working-directory: ${{ env.PROGRAM_NAME }}
+        run: |
+          version="${{ matrix.version }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib $libpath/libgcc_s.1.1.dylib.bak
+          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
+          mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak
+          mv $libpath/libstdc++.6.dylib $libpath/libstdc++.6.dylib.bak
+
+      # static link libgcc
+      - name: Set LDFLAGS (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          ldflags="$LDFLAGS -static-libgcc"
+          echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
+
       - name: Build single precision version of ${{ env.PROGRAM_NAME }}
         working-directory: ${{ env.PROGRAM_NAME }}
         run: |
@@ -76,6 +96,15 @@ jobs:
           pixi run setup builddir-dble -Ddouble=true
           pixi run build builddir-dble
 
+      - name: Check architecture (macOS)
+        working-directory: ${{ env.PROGRAM_NAME }}/bin
+        if: runner.os == 'macOS'
+        run: |
+          otool -L mfusg
+          otool -L mfusgdbl
+          lipo -info mfusg
+          lipo -info mfusgdbl
+
       - name: Show build log
         if: failure()
         working-directory: ${{ env.PROGRAM_NAME }}
@@ -85,7 +114,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: meson-log.txt
+          name: ${{ matrix.os }}-${{ matrix.compiler}}-${{ matrix.version }}-meson-log.txt
           path: ${{ env.PROGRAM_NAME }}/builddir/meson-logs/meson-log.txt
 
       - name: Create source zip file on Linux

--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 
 # MODFLOW-USG
 
-
+[![mfusg checks](https://github.com/MODFLOW-ORG/mfusg/actions/workflows/ci.yml/badge.svg)](https://github.com/MODFLOW-ORG/mfusg/actions/workflows/ci.yml)
 
 [USGS Release Page](https://water.usgs.gov/ogw/mfusg)
-
-## Automated Testing Status on Travis-CI
-
-### Version 1.4.01 develop
-[![Build Status](https://travis-ci.com/MODFLOW-USGS/mfusg.svg?branch=develop)](https://travis-ci.com/MODFLOW-USGS/mfusg)
 
 ## Introduction
 

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ fc_id = fc.get_id()
 message('Compiler ID:', fc_id)
 compile_args = []
 link_args = []
+extra_deps = []
 
 # Command line options for gfortran
 if fc_id == 'gcc'
@@ -58,6 +59,12 @@ if fc_id == 'gcc'
     compile_args += '-D__APPLE__'
   elif system == 'windows'
     compile_args += '-D_WIN32'
+  endif
+
+  # Link quadmath library on macOS (required for gfortran runtime)
+  if host_machine.system() == 'darwin'
+    quadmath_dep = fc.find_library('quadmath', required: true, static: true)
+    extra_deps += [quadmath_dep]
   endif
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,5 +39,5 @@ mfusg_sources = files(
 mfusg = executable(buildname,
                     mfusg_sources,
                     dependencies: extra_deps,
-                    link_language : 'fortran,
+                    link_language : 'fortran',
                     install: true)

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,4 +38,6 @@ mfusg_sources = files(
 
 mfusg = executable(buildname,
                     mfusg_sources,
+                    dependencies: extra_deps,
+                    link_language : 'fortran,
                     install: true)


### PR DESCRIPTION
* switch `macos-15-intel` build from intel classic to gcc/gfortran
* hide dylibs, use `-static-libgcc`, and add explicit libquadmath dependency in `meson.build` for static(ish) gfortran build on mac
* set link language to fortran in `meson.build` (defensive)
* unique name for uploaded build logs on failure
* add CI badge to README